### PR TITLE
Stop process if there are troubles connecting to daemon.

### DIFF
--- a/src/CoiniumServ/Pools/NetworkInfo.cs
+++ b/src/CoiniumServ/Pools/NetworkInfo.cs
@@ -183,14 +183,17 @@ namespace CoiniumServ.Pools
             }
 
             if (Healthy && FailedHealthChecks > 0) {
+                _logger.Error("Healthy again.");
                 FailedHealthChecks = 0;
             }
 
             if (!Healthy) {
+                _logger.Error("Unhealthy, updating failure counter.");
                 ++FailedHealthChecks;
             }
 
             if (!Healthy && FailedHealthChecks >= MaxFailedHealthChecks) {
+                _logger.Error("Healthcheck failures maximum reached.");
                 Process.GetCurrentProcess().Kill();
             }
         }

--- a/src/CoiniumServ/Pools/NetworkInfo.cs
+++ b/src/CoiniumServ/Pools/NetworkInfo.cs
@@ -28,6 +28,7 @@
 #endregion
 
 using System;
+using System.Diagnostics;
 using CoiniumServ.Algorithms;
 using CoiniumServ.Daemon;
 using CoiniumServ.Daemon.Errors;
@@ -63,6 +64,8 @@ namespace CoiniumServ.Pools
 
         public bool Healthy { get; private set; }
 
+        public UInt64 FailedHealthChecks { get; private set; }
+
         public string ServiceResponse { get; private set; } // todo implement this too for /pool/COIN/network
 
         private readonly IDaemonClient _daemonClient;
@@ -72,6 +75,8 @@ namespace CoiniumServ.Pools
         private readonly IPoolConfig _poolConfig;
 
         private readonly ILogger _logger;
+
+        private static UInt64 MaxFailedHealthChecks = 3;
 
         public NetworkInfo(IDaemonClient daemonClient, IHashAlgorithm hashAlgorithm, IPoolConfig poolConfig)
         {
@@ -175,6 +180,18 @@ namespace CoiniumServ.Pools
             {
                 _logger.Error("Can not read getblocktemplate(): {0:l}", e.Message);
                 Reward = 0;
+            }
+
+            if (Healthy && FailedHealthChecks > 0) {
+                FailedHealthChecks = 0;
+            }
+
+            if (!Healthy) {
+                ++FailedHealthChecks;
+            }
+
+            if (!Healthy && FailedHealthChecks >= MaxFailedHealthChecks) {
+                Process.GetCurrentProcess().Kill();
             }
         }
 

--- a/src/CoiniumServ/Pools/NetworkInfo.cs
+++ b/src/CoiniumServ/Pools/NetworkInfo.cs
@@ -188,8 +188,8 @@ namespace CoiniumServ.Pools
             }
 
             if (!Healthy) {
-                _logger.Error("Unhealthy, updating failure counter.");
                 ++FailedHealthChecks;
+                _logger.Error("Unhealthy. Updating failure counter. New value: {0}.", FailedHealthChecks);
             }
 
             if (!Healthy && FailedHealthChecks >= MaxFailedHealthChecks) {


### PR DESCRIPTION
Since it's a single-coin pool, there is no reason to keep service running in case of troubles.
Some problems can be fixed by restart, so let the process manager restart it.